### PR TITLE
prevent recruiters to comment on github in order to recruit

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ eyes.
 # Guide points
 
 * ...pull requests here pls
+* It's considered inappropriate to advertise or contact developers by
+  commenting on their OpenSource projects or posting any irrelevant content that aims
+  to spread recruiting activities on
+  developers/programmers public repositories(like Github, Bitbucket), blogs and portfolios.


### PR DESCRIPTION
related to discussions:
- https://www.reddit.com/r/ruby/comments/4wwjgw/link_to_discussion_recruiter_is_spamming_comment/
- https://www.reddit.com/r/programming/comments/4wwh7j/link_to_discussion_recruiter_is_spamming_comment/
